### PR TITLE
test: add unit tests for rating calculation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ A Streamlit web app that calculates unofficial PDGA (Professional Disc Golf Asso
 - **Run the app:** `cd pdga_whats_my_rating && uv run streamlit run Home.py`
 - **Lint:** `uv run ruff check .`
 - **Format:** `uv run ruff format .`
+- **Test:** `uv run pytest`
 
 ## Architecture
 
@@ -28,5 +29,6 @@ A Streamlit web app that calculates unofficial PDGA (Professional Disc Golf Asso
 - Streamlit caching (`@st.cache_data`) is used on `calculate_rating` and `get_data`
 - Imports in `Home.py` use relative-style paths (e.g., `from utils.rating_calc import ...`) — the app must be run from inside the `pdga_whats_my_rating/` directory
 - Query param `pdga_no` enables bookmarkable player lookups
-- No test suite exists yet (`tests/` contains only `__init__.py`)
+- Tests use pytest with `pythonpath = ["pdga_whats_my_rating"]` in pyproject.toml
+- `tests/conftest.py` patches `st.cache_data` to a no-op for test compatibility
 - The rating algorithm's +5 buffer on the outlier threshold is an approximation of PDGA's actual calculation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,13 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "pytest>=9.0.2",
     "ruff>=0.15.5",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["pdga_whats_my_rating"]
 
 [tool.ruff]
 target-version = "py312"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from unittest.mock import patch
+
+
+def _passthrough_decorator(func=None, **kwargs):
+    """Replace st.cache_data with a no-op decorator for tests."""
+    if func is not None:
+        return func
+    return lambda f: f
+
+
+# Patch st.cache_data before any module imports it
+patch("streamlit.cache_data", _passthrough_decorator).start()

--- a/tests/test_rating_calc.py
+++ b/tests/test_rating_calc.py
@@ -1,0 +1,136 @@
+import math
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+
+from utils.rating_calc import calculate_rating
+
+
+def make_df(ratings, dates=None, tiers=None, rounds=None):
+    """Helper to build a ratings DataFrame for testing."""
+    n = len(ratings)
+    if dates is None:
+        base = datetime.now()
+        dates = [base - timedelta(days=i * 14) for i in range(n)]
+    if tiers is None:
+        tiers = ["A"] * n
+    if rounds is None:
+        rounds = [1] * n
+    return pd.DataFrame(
+        {
+            "rating": ratings,
+            "date": pd.to_datetime(dates),
+            "tier": tiers,
+            "round": rounds,
+        }
+    )
+
+
+class TestCalculateRating:
+    def test_basic_rating_calculation(self):
+        """Rating should be close to the average of input ratings."""
+        ratings = [900, 910, 920, 905, 915, 895, 910, 920]
+        df = make_df(ratings)
+        _, calc_rating, _ = calculate_rating(df, 910)
+        # Should be in the ballpark of the input ratings
+        assert 890 <= calc_rating <= 930
+
+    def test_weighted_average(self):
+        """Most recent 25% of rounds should be double-weighted."""
+        # 8 rounds: last 25% (2 most recent) are double-weighted
+        ratings = [1000, 1000, 900, 900, 900, 900, 900, 900]
+        df = make_df(ratings)
+        _, calc_rating, _ = calculate_rating(df, 950)
+        # weighted avg = (1000*2 + 1000*2 + 900*6) / 10 = 940
+        assert calc_rating == math.ceil(9400 / 10)
+
+    def test_xm_tier_excluded(self):
+        """XM tier rounds should be excluded from calculation."""
+        ratings = [900, 910, 920, 905, 800]
+        tiers = ["A", "A", "A", "A", "XM"]
+        df = make_df(ratings, tiers=tiers)
+        result_df, calc_rating, _ = calculate_rating(df, 900)
+        assert "XM" not in result_df["tier"].values
+        # Without the 800 XM round, rating should be higher
+        assert calc_rating > 800
+
+    def test_12_month_window(self):
+        """Rounds older than 12 months should not be evaluated."""
+        now = datetime.now()
+        dates = [
+            now - timedelta(days=30),
+            now - timedelta(days=60),
+            now - timedelta(days=90),
+            now - timedelta(days=120),
+            now - timedelta(days=400),  # older than 12 months
+        ]
+        ratings = [900, 910, 920, 905, 500]
+        df = make_df(ratings, dates=dates)
+        result_df, calc_rating, _ = calculate_rating(df, 900)
+        old_row = result_df[result_df["rating"] == 500].iloc[0]
+        assert old_row["evaluated"] == "No"
+        assert old_row["weight"] == 0
+        # Rating should not be dragged down by the old 500
+        assert calc_rating > 850
+
+    def test_outlier_removal_std_threshold(self):
+        """Rounds below 2.5 SD + 5 buffer should be dropped."""
+        ratings = [950, 950, 950, 950, 950, 950, 950, 950, 600]
+        df = make_df(ratings)
+        result_df, _, threshold = calculate_rating(df, 950)
+        outlier_row = result_df[result_df["rating"] == 600].iloc[0]
+        assert outlier_row["used"] == "No"
+        assert outlier_row["weight"] == 0
+
+    def test_outlier_100_point_threshold(self):
+        """When 2.5 SD > 100, use 100-point threshold instead."""
+        # High variance so 2.5*SD > 100
+        ratings = [1000, 900, 800, 1000, 900, 800, 1000, 900, 800]
+        df = make_df(ratings)
+        std = np.std(ratings, ddof=0)
+        avg = np.mean(ratings)
+        assert (2.5 * std) >= 100
+        _, _, threshold = calculate_rating(df, 900)
+        assert threshold == math.ceil(avg - 100)
+
+    def test_used_column_reflects_weights(self):
+        """'used' column should be 'Yes' only for weight > 0."""
+        ratings = [900, 910, 920, 905, 915, 895, 910, 920]
+        df = make_df(ratings)
+        result_df, _, _ = calculate_rating(df, 910)
+        for _, row in result_df.iterrows():
+            if row["weight"] > 0:
+                assert row["used"] == "Yes"
+            else:
+                assert row["used"] == "No"
+
+    def test_moving_averages_present(self):
+        """Result should have mavg_5 and mavg_15 columns."""
+        ratings = [900, 910, 920, 930, 940]
+        df = make_df(ratings)
+        result_df, _, _ = calculate_rating(df, 920)
+        assert "mavg_5" in result_df.columns
+        assert "mavg_15" in result_df.columns
+        assert not result_df["mavg_5"].isna().any()
+        assert not result_df["mavg_15"].isna().any()
+
+    def test_double_weight_count(self):
+        """Last 25% of evaluated rounds should have weight=2."""
+        ratings = [900 + i * 5 for i in range(12)]
+        df = make_df(ratings)
+        result_df, _, _ = calculate_rating(df, 930)
+        evaluated = result_df[result_df["evaluated"] == "Yes"]
+        expected_double = round(len(evaluated) * 0.25)
+        actual_double = len(result_df[result_df["weight"] == 2])
+        assert actual_double == expected_double
+
+    def test_returns_tuple_of_three(self):
+        """calculate_rating returns (df, rating, threshold)."""
+        ratings = [900, 910, 920, 905]
+        df = make_df(ratings)
+        result = calculate_rating(df, 900)
+        assert len(result) == 3
+        assert isinstance(result[0], pd.DataFrame)
+        assert isinstance(result[1], int)
+        assert isinstance(result[2], (int, float))

--- a/uv.lock
+++ b/uv.lock
@@ -518,6 +518,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -999,6 +1008,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -1010,7 +1020,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.15.5" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "ruff", specifier = ">=0.15.5" },
+]
 
 [[package]]
 name = "pillow"
@@ -1104,6 +1117,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1193,6 +1215,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1234,6 +1265,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Added pytest as dev dependency with config in `pyproject.toml`
- Created `tests/conftest.py` to patch `st.cache_data` for test compatibility
- Created `tests/test_rating_calc.py` with 10 tests covering:
  - Basic rating calculation
  - Weighted average (last 25% double-weighted)
  - XM tier exclusion
  - 12-month window filtering
  - Outlier removal (2.5 SD and 100-point thresholds)
  - Used column reflects weights
  - Moving averages present
  - Double-weight count
  - Return type validation
- Updated CLAUDE.md with test command and notes

## Test plan
- [x] `uv run pytest -v` — 10/10 passing

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)