### PR TITLE
Fix input revert bug and add 429 handling

### DIFF
--- a/pdga_whats_my_rating/Home.py
+++ b/pdga_whats_my_rating/Home.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import requests
 import streamlit as st
 from classes.player import Player
 from utils import figs
@@ -8,21 +9,21 @@ st.set_page_config(page_title="What's My Rating?", page_icon="🥏", layout="wid
 
 CONTINUE = True
 
-pdga_from_query = st.query_params.get("pdga_no", None)
-
-if "player" not in st.session_state:
-    st.session_state["player"] = None
-
+# seed widget state from query param on first load only
+auto_load = False
+if "pdga_input" not in st.session_state:
+    pdga_from_query = st.query_params.get("pdga_no", "")
+    if pdga_from_query:
+        st.session_state["pdga_input"] = pdga_from_query
+        auto_load = True
 
 # actual page layout and content
 st.title("What's My Rating?")
 with st.form("form"):
-    pdga_no = st.text_input(
-        "Enter your PDGA number:", pdga_from_query if pdga_from_query else ""
-    )
+    pdga_no = st.text_input("Enter your PDGA number:", key="pdga_input")
     submit = st.form_submit_button("Get Data")
 
-if submit or pdga_from_query:
+if submit or auto_load:
     try:
         int(pdga_no)
     except ValueError:
@@ -30,14 +31,31 @@ if submit or pdga_from_query:
         st.error("must be a valid pdga number")
 
     if CONTINUE:
+        st.session_state["pdga_no"] = pdga_no
         st.query_params["pdga_no"] = pdga_no
         try:
             player = Player(pdga_no)
-            st.session_state["player"] = player
+        except requests.exceptions.HTTPError as e:
+            CONTINUE = False
+            if e.response is not None and e.response.status_code == 429:
+                st.error(
+                    "PDGA.com is rate limiting requests."
+                    " Please wait a minute and try again."
+                )
+            else:
+                st.error(
+                    f"player info not available for pdga number"
+                    f" {pdga_no}\n"
+                    " Are you sure this is a valid PDGA number?"
+                    " If this is a valid PDGA number,"
+                    " please reach out to me! Thanks."
+                )
+            print(e)
         except Exception as e:
             CONTINUE = False
             st.error(
-                f"player info not available for pdga number {pdga_no}\n"
+                f"player info not available for pdga number"
+                f" {pdga_no}\n"
                 " Are you sure this is a valid PDGA number?"
                 " If this is a valid PDGA number,"
                 " please reach out to me! Thanks."


### PR DESCRIPTION
## Summary
- Fix text input reverting to previous PDGA number on consecutive searches, caused by `st.query_params` conflicting with widget state
- Show "PDGA.com is rate limiting requests" for 429 errors instead of the misleading "invalid PDGA number" message

Closes #33

## Test plan
- [x] All 17 tests pass
- [x] Lint and format clean
- [x] Manually tested: enter 167210, submit, then change to 167214, submit — no revert
- [x] Bookmark URL (`?pdga_no=167210`) still auto-loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)