### PR TITLE
Fix deprecated use_container_width warnings

### DIFF
--- a/pdga_whats_my_rating/Home.py
+++ b/pdga_whats_my_rating/Home.py
@@ -125,17 +125,17 @@ if submit or auto_load:
 
             # rating w moving avg
             fig1 = figs.mavg_chart(df)
-            col1.plotly_chart(fig1, use_container_width=True)
+            col1.plotly_chart(fig1, width="stretch")
 
             # boxplots
             fig2 = figs.div_box_chart(df)
-            col2.plotly_chart(fig2, use_container_width=True)
+            col2.plotly_chart(fig2, width="stretch")
 
             st.subheader("Rating Detail")
             st.dataframe(
                 df.drop(columns=["mavg_5", "mavg_15"]),
                 hide_index=True,
-                use_container_width=True,
+                width="stretch",
             )
 
         else:


### PR DESCRIPTION
## Summary
- Replace all `use_container_width=True` with `width="stretch"` in `Home.py` to resolve Streamlit deprecation warnings

Fixes #38

## Test plan
- [x] Run the app and verify no deprecation warnings in logs
- [x] Verify charts and dataframe still render full-width

🤖 Generated with [Claude Code](https://claude.com/claude-code)