### PR TITLE
feat: align rating calculator with PDGA official rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ A Streamlit web app that calculates unofficial PDGA (Professional Disc Golf Asso
 
 - **`pdga_whats_my_rating/Home.py`** — Streamlit entrypoint. Handles form input, displays metrics, charts, and data tables.
 - **`classes/player.py`** — `Player` class that scrapes pdga.com for a player's info, ratings detail, and recent events. Fetches from three sources: player home page, `/details` page, and individual tournament pages for new (not-yet-rated) tournaments.
-- **`utils/rating_calc.py`** — `calculate_rating()` implements the PDGA rating algorithm: 12-month window, last 25% double-weighted, outlier drop at 2.5 SD (or 100 points) below average, excludes XM tier.
+- **`utils/rating_calc.py`** — `calculate_rating()` implements the PDGA rating algorithm: 12/24-month window, last 25% double-weighted (≥9 rounds), outlier drop at 2.5 SD or 100 points below average (≥7 rounds), excludes XM tier. Returns `(df, rating, threshold, window_months)`.
 - **`utils/figs.py`** — Plotly chart builders: rating history bar chart with 5/15 moving averages, and division box plot.
 
 ## Workflow
@@ -40,11 +40,12 @@ A Streamlit web app that calculates unofficial PDGA (Professional Disc Golf Asso
 
 ## PDGA Official Rating Algorithm
 
-Per PDGA documentation:
+Per [PDGA ratings guide](https://pdga.com/ratings/guide):
 - **12-month window** from most recent rated round
-- **Double-weight most recent 25%** once player has ≥9 rated rounds
-- **<8 rounds in 12 months**: look back up to 24 months to find ≥8 rounds (not yet implemented)
-- **Outlier removal** (≥7 rounds): drop rounds >2.5 SD or >100 points below average
+- **24-month lookback**: if <8 rounds in 12 months, extend window to 24 months
+- **Double-weight most recent 25%** only when ≥9 evaluated rounds
+- **Outlier removal** only when ≥7 evaluated rounds: drop rounds >2.5 SD or >100 points below average
+- **Hole count weighting**: 18-hole = 1x, 27-hole = 1.5x (not yet implemented — requires scraping individual tournament pages)
 - **Incomplete rounds** are excluded
 
 ### Our implementation vs PDGA
@@ -52,7 +53,7 @@ Per PDGA documentation:
 - The `+5` buffer on the outlier threshold is an empirical approximation — helps match PDGA results but the exact rule is unknown
 - Outlier removal is iterative: dropping one outlier shifts avg/std, which can expose additional outliers
 - The double-weight count (`round(n * 0.25)`) is computed from evaluated rounds before outlier removal, then applied to remaining rounds after removal
-- The 24-month lookback for <8 rounds is not yet implemented
+- Hole count weighting is not yet implemented — the PDGA ratings detail page doesn't include hole counts (see separate issue)
 - One known unexplained gap: Josh (167214) is off by 6 — PDGA drops a round (899) that doesn't trigger any threshold we can compute. Likely an unpublished PDGA rule.
 
 ## Testing

--- a/pdga_whats_my_rating/Home.py
+++ b/pdga_whats_my_rating/Home.py
@@ -117,7 +117,7 @@ def show_player(pdga_no):
         )
 
     official_rating = player.cur_rating
-    df, calc_rating, drop_thres = calculate_rating(df)
+    df, calc_rating, drop_thres, window_months = calculate_rating(df)
 
     st.markdown(
         f"### [{player.name}](https://pdga.com/player/{pdga_no})"
@@ -144,14 +144,26 @@ def show_player(pdga_no):
             f"Rounds Evaluated: {n_evaluated}\n"
             f"Rounds Used: {n_used}\n",
         )
-        msg = (
-            f"*You have no new rounds, so our calculation"
-            f" should match your official rating exactly,"
-            f" but we're off by {diff}."
-        )
-        if link:
-            msg += f" Please [let me know]({link}) so I can improve the algorithm!"
-        msg += "*"
+        if diff <= 2:
+            msg = (
+                f"*You have no new rounds, so our calculation"
+                f" should match your official rating exactly,"
+                f" but we're off by {diff}. Small differences"
+                f" are usually due to rounding or minor aspects"
+                f" of the PDGA algorithm we can't fully replicate"
+                f" (e.g. hole count weighting).*"
+            )
+        else:
+            msg = (
+                f"*You have no new rounds, so our calculation"
+                f" should match your official rating exactly,"
+                f" but we're off by {diff}. Small differences"
+                f" can happen due to rounding, but this gap is"
+                f" larger than expected."
+            )
+            if link:
+                msg += f" Please [let me know]({link}) so I can improve the algorithm!"
+            msg += "*"
         col1.markdown(msg)
     col2.metric(
         f"Official Rating {player.rating_date}",
@@ -214,11 +226,11 @@ def show_player(pdga_no):
                 (merged["pdga_evaluated"] == "Yes") & (merged["evaluated"] == "No")
             ]
             if not dropped.empty:
-                st.markdown("#### Rounds Dropped from 12-Month Window")
+                st.markdown(f"#### Rounds Dropped from {window_months}-Month Window")
                 st.caption(
                     "These rounds were in your last official rating"
-                    " but have since fallen outside the 12-month"
-                    " window."
+                    f" but have since fallen outside the {window_months}-month"
+                    " evaluation window."
                 )
                 st.dataframe(
                     dropped[["tournament", "date", "round", "rating", "tier"]],
@@ -226,7 +238,7 @@ def show_player(pdga_no):
                 )
             else:
                 st.markdown(
-                    "**No rounds dropped from the 12-month window**"
+                    f"**No rounds dropped from the {window_months}-month window**"
                     " since your last official rating."
                 )
 
@@ -235,7 +247,7 @@ def show_player(pdga_no):
         if not outliers.empty:
             st.markdown("#### Rounds Dropped as Outliers")
             st.caption(
-                "These rounds are within the 12-month window but"
+                f"These rounds are within the {window_months}-month window but"
                 " were dropped because their rating is at or below"
                 f" the drop threshold (~{int(drop_thres)})."
             )

--- a/pdga_whats_my_rating/utils/rating_calc.py
+++ b/pdga_whats_my_rating/utils/rating_calc.py
@@ -8,9 +8,10 @@ import streamlit as st
 @st.cache_data
 def calculate_rating(df):
     """
-    12 months prior to latest round
-    last 25% are worth double
-    2.5 SD below rating is dropped
+    PDGA rating algorithm:
+    - 12-month window (extended to 24 months if <8 rounds)
+    - Last 25% double-weighted (only when ≥9 evaluated rounds)
+    - Outlier removal at 2.5 SD / 100 pts below avg (only when ≥7 rounds)
     """
     df = df.copy()
     df["date"] = pd.to_datetime(df["date"], format="mixed")
@@ -27,33 +28,46 @@ def calculate_rating(df):
     max_date = df["date"].max()
     min_date = max_date - pd.DateOffset(years=1)
     valid_dates = df["date"] >= min_date
+
+    # If <8 rounds in 12 months, extend to 24 months (PDGA rule)
+    window_months = 12
+    if valid_dates.sum() < 8:
+        min_date = max_date - pd.DateOffset(years=2)
+        valid_dates = df["date"] >= min_date
+        window_months = 24
+
     df.loc[valid_dates, "weight"] = 1
     df.loc[valid_dates, "evaluated"] = "Yes"
 
     # double the last 25% (computed before outlier removal)
-    num_double = round(len(df[valid_dates]) * 0.25)
-    df.loc[: (num_double - 1), "weight"] = 2
+    # only when ≥9 evaluated rounds (PDGA rule)
+    evaluated_count = valid_dates.sum()
+    if evaluated_count >= 9:
+        num_double = round(evaluated_count * 0.25)
+        df.loc[: (num_double - 1), "weight"] = 2
 
     # iteratively remove outliers — dropping a round shifts the
     # avg/std, which may expose additional outliers.
+    # Only when ≥7 evaluated rounds (PDGA rule).
     # 10 is just a safety cap; typically converges in 2-3 passes.
     threshold = 0
-    for _ in range(10):
-        used_mask = df["weight"] > 0
-        if used_mask.sum() == 0:
-            break
-        std = df.loc[used_mask, "rating"].std(ddof=0)
-        if std == 0:
-            break
-        avg = df.loc[used_mask, "rating"].mean()
-        if (2.5 * std) < 100:
-            new_threshold = math.ceil(avg - math.floor(2.5 * std)) + 5
-        else:
-            new_threshold = math.ceil(avg - 100)
-        if new_threshold == threshold:
-            break
-        threshold = new_threshold
-        df.loc[df["rating"] <= threshold, "weight"] = 0
+    if (df["weight"] > 0).sum() >= 7:
+        for _ in range(10):
+            used_mask = df["weight"] > 0
+            if used_mask.sum() == 0:
+                break
+            std = df.loc[used_mask, "rating"].std(ddof=0)
+            if std == 0:
+                break
+            avg = df.loc[used_mask, "rating"].mean()
+            if (2.5 * std) < 100:
+                new_threshold = math.ceil(avg - math.floor(2.5 * std)) + 5
+            else:
+                new_threshold = math.ceil(avg - 100)
+            if new_threshold == threshold:
+                break
+            threshold = new_threshold
+            df.loc[df["rating"] <= threshold, "weight"] = 0
 
     # set used col
     df.loc[df["weight"] > 0, "used"] = "Yes"
@@ -68,8 +82,8 @@ def calculate_rating(df):
 
     # rating
     if df["weight"].sum() == 0:
-        return df, 0, threshold
+        return df, 0, threshold, window_months
 
     rating = np.average(df.rating, weights=df.weight)
 
-    return df, int(math.ceil(rating)), threshold
+    return df, int(math.ceil(rating)), threshold, window_months

--- a/tests/test_rating_accuracy.py
+++ b/tests/test_rating_accuracy.py
@@ -36,7 +36,7 @@ FIXTURES_DIR = "tests/fixtures"
 )
 def test_matches_official_rating(fixture_file, official_rating, tolerance):
     df = pd.read_csv(f"{FIXTURES_DIR}/{fixture_file}", parse_dates=["date"])
-    _, calc_rating, _ = calculate_rating(df)
+    _, calc_rating, _, _ = calculate_rating(df)
     diff = abs(calc_rating - official_rating)
     assert diff <= tolerance, (
         f"Calculated {calc_rating}, official {official_rating}, "

--- a/tests/test_rating_calc.py
+++ b/tests/test_rating_calc.py
@@ -31,25 +31,25 @@ class TestCalculateRating:
         """Rating should be close to the average of input ratings."""
         ratings = [900, 910, 920, 905, 915, 895, 910, 920]
         df = make_df(ratings)
-        _, calc_rating, _ = calculate_rating(df)
+        _, calc_rating, _, _ = calculate_rating(df)
         # Should be in the ballpark of the input ratings
         assert 890 <= calc_rating <= 930
 
     def test_weighted_average(self):
-        """Most recent 25% of rounds should be double-weighted."""
-        # 8 rounds: last 25% (2 most recent) are double-weighted
-        ratings = [1000, 1000, 900, 900, 900, 900, 900, 900]
+        """Most recent 25% of rounds should be double-weighted (≥9 rounds)."""
+        # 9 rounds: last 25% (2 most recent) are double-weighted
+        ratings = [1000, 1000, 900, 900, 900, 900, 900, 900, 900]
         df = make_df(ratings)
-        _, calc_rating, _ = calculate_rating(df)
-        # weighted avg = (1000*2 + 1000*2 + 900*6) / 10 = 940
-        assert calc_rating == math.ceil(9400 / 10)
+        _, calc_rating, _, _ = calculate_rating(df)
+        # weighted avg = (1000*2 + 1000*2 + 900*7) / 11 = 10300/11 = 937
+        assert calc_rating == math.ceil(10300 / 11)
 
     def test_xm_tier_excluded(self):
         """XM tier rounds should be excluded from calculation."""
         ratings = [900, 910, 920, 905, 800]
         tiers = ["A", "A", "A", "A", "XM"]
         df = make_df(ratings, tiers=tiers)
-        result_df, calc_rating, _ = calculate_rating(df)
+        result_df, calc_rating, _, _ = calculate_rating(df)
         assert "XM" not in result_df["tier"].values
         # Without the 800 XM round, rating should be higher
         assert calc_rating > 800
@@ -62,11 +62,15 @@ class TestCalculateRating:
             now - timedelta(days=60),
             now - timedelta(days=90),
             now - timedelta(days=120),
+            now - timedelta(days=150),
+            now - timedelta(days=180),
+            now - timedelta(days=210),
+            now - timedelta(days=240),
             now - timedelta(days=400),  # older than 12 months
         ]
-        ratings = [900, 910, 920, 905, 500]
+        ratings = [900, 910, 920, 905, 915, 895, 910, 920, 500]
         df = make_df(ratings, dates=dates)
-        result_df, calc_rating, _ = calculate_rating(df)
+        result_df, calc_rating, _, _ = calculate_rating(df)
         old_row = result_df[result_df["rating"] == 500].iloc[0]
         assert old_row["evaluated"] == "No"
         assert old_row["weight"] == 0
@@ -77,7 +81,7 @@ class TestCalculateRating:
         """Rounds below 2.5 SD + 5 buffer should be dropped."""
         ratings = [950, 950, 950, 950, 950, 950, 950, 950, 600]
         df = make_df(ratings)
-        result_df, _, threshold = calculate_rating(df)
+        result_df, _, threshold, _ = calculate_rating(df)
         outlier_row = result_df[result_df["rating"] == 600].iloc[0]
         assert outlier_row["used"] == "No"
         assert outlier_row["weight"] == 0
@@ -89,7 +93,7 @@ class TestCalculateRating:
         df = make_df(ratings)
         std = np.std(ratings, ddof=0)
         assert (2.5 * std) >= 100
-        result_df, _, threshold = calculate_rating(df)
+        result_df, _, threshold, _ = calculate_rating(df)
         # 800s are dropped on first pass, then threshold shifts
         # on second pass based on remaining [1000, 900] rounds
         assert all(result_df[result_df["rating"] == 800]["weight"] == 0)
@@ -98,7 +102,7 @@ class TestCalculateRating:
         """'used' column should be 'Yes' only for weight > 0."""
         ratings = [900, 910, 920, 905, 915, 895, 910, 920]
         df = make_df(ratings)
-        result_df, _, _ = calculate_rating(df)
+        result_df, _, _, _ = calculate_rating(df)
         for _, row in result_df.iterrows():
             if row["weight"] > 0:
                 assert row["used"] == "Yes"
@@ -109,7 +113,7 @@ class TestCalculateRating:
         """Result should have mavg_5 and mavg_15 columns."""
         ratings = [900, 910, 920, 930, 940]
         df = make_df(ratings)
-        result_df, _, _ = calculate_rating(df)
+        result_df, _, _, _ = calculate_rating(df)
         assert "mavg_5" in result_df.columns
         assert "mavg_15" in result_df.columns
         assert not result_df["mavg_5"].isna().any()
@@ -119,18 +123,104 @@ class TestCalculateRating:
         """Last 25% of evaluated rounds should have weight=2."""
         ratings = [900 + i * 5 for i in range(12)]
         df = make_df(ratings)
-        result_df, _, _ = calculate_rating(df)
+        result_df, _, _, _ = calculate_rating(df)
         evaluated = result_df[result_df["evaluated"] == "Yes"]
         expected_double = round(len(evaluated) * 0.25)
         actual_double = len(result_df[result_df["weight"] == 2])
         assert actual_double == expected_double
 
-    def test_returns_tuple_of_three(self):
-        """calculate_rating returns (df, rating, threshold)."""
+    def test_returns_tuple_of_four(self):
+        """calculate_rating returns (df, rating, threshold, window_months)."""
         ratings = [900, 910, 920, 905]
         df = make_df(ratings)
         result = calculate_rating(df)
-        assert len(result) == 3
+        assert len(result) == 4
         assert isinstance(result[0], pd.DataFrame)
         assert isinstance(result[1], int)
         assert isinstance(result[2], (int, float))
+        assert result[3] in (12, 24)
+
+    def test_no_double_weight_below_9_rounds(self):
+        """With <9 rounds, no double-weighting should be applied."""
+        ratings = [1000, 1000, 900, 900, 900, 900, 900, 900]  # 8 rounds
+        df = make_df(ratings)
+        result_df, _, _, _ = calculate_rating(df)
+        assert (result_df["weight"] == 2).sum() == 0
+
+    def test_double_weight_at_9_rounds(self):
+        """With exactly 9 rounds, double-weighting should apply."""
+        ratings = [1000, 1000, 900, 900, 900, 900, 900, 900, 900]
+        df = make_df(ratings)
+        result_df, _, _, _ = calculate_rating(df)
+        double_weighted = result_df[result_df["weight"] == 2]
+        assert len(double_weighted) == round(9 * 0.25)  # 2 rounds
+
+    def test_no_outlier_removal_below_7_rounds(self):
+        """With <7 rounds, outliers should NOT be removed."""
+        ratings = [950, 950, 950, 950, 950, 600]  # 6 rounds, 600 is an outlier
+        df = make_df(ratings)
+        result_df, _, _, _ = calculate_rating(df)
+        outlier_row = result_df[result_df["rating"] == 600].iloc[0]
+        assert outlier_row["used"] == "Yes"
+        assert outlier_row["weight"] > 0
+
+    def test_outlier_removal_at_7_rounds(self):
+        """With ≥7 rounds, outliers should be removed."""
+        ratings = [950, 950, 950, 950, 950, 950, 600]  # 7 rounds
+        df = make_df(ratings)
+        result_df, _, _, _ = calculate_rating(df)
+        outlier_row = result_df[result_df["rating"] == 600].iloc[0]
+        assert outlier_row["used"] == "No"
+        assert outlier_row["weight"] == 0
+
+    def test_24_month_lookback(self):
+        """With <8 rounds in 12 months, extend window to 24 months."""
+        now = datetime.now()
+        dates = [
+            now - timedelta(days=30),
+            now - timedelta(days=60),
+            now - timedelta(days=90),
+            now - timedelta(days=120),
+            now - timedelta(days=150),
+            # 5 rounds in 12 months, need to look back further
+            now - timedelta(days=400),
+            now - timedelta(days=420),
+            now - timedelta(days=440),
+            now - timedelta(days=460),
+            now - timedelta(days=480),
+        ]
+        ratings = [900, 910, 920, 905, 915, 890, 885, 895, 880, 870]
+        df = make_df(ratings, dates=dates)
+        result_df, _, _, window_months = calculate_rating(df)
+        assert window_months == 24
+        # Rounds from 12-24 months ago should be evaluated
+        old_rows = result_df[result_df["rating"].isin([890, 885, 895, 880, 870])]
+        assert (old_rows["evaluated"] == "Yes").all()
+
+    def test_no_lookback_when_enough_rounds(self):
+        """With ≥8 rounds in 12 months, use standard 12-month window."""
+        now = datetime.now()
+        dates = [now - timedelta(days=i * 14) for i in range(10)]
+        dates.append(now - timedelta(days=400))  # old round
+        ratings = [900 + i * 5 for i in range(10)] + [800]
+        df = make_df(ratings, dates=dates)
+        result_df, _, _, window_months = calculate_rating(df)
+        assert window_months == 12
+        old_row = result_df[result_df["rating"] == 800].iloc[0]
+        assert old_row["evaluated"] == "No"
+
+    def test_24_month_lookback_still_few(self):
+        """With <8 rounds even in 24 months, use what's available."""
+        now = datetime.now()
+        dates = [
+            now - timedelta(days=30),
+            now - timedelta(days=60),
+            now - timedelta(days=400),
+            now - timedelta(days=420),
+            now - timedelta(days=440),
+        ]
+        ratings = [900, 910, 890, 885, 895]
+        df = make_df(ratings, dates=dates)
+        result_df, _, _, window_months = calculate_rating(df)
+        assert window_months == 24
+        assert (result_df["evaluated"] == "Yes").all()


### PR DESCRIPTION
## Summary
- **24-month lookback**: extends evaluation window from 12 to 24 months when <8 rounds in the 12-month window
- **≥9 guard for double-weighting**: only applies double-weighting when there are 9+ evaluated rounds
- **≥7 guard for outlier removal**: only runs outlier removal when there are 7+ evaluated rounds
- **Dynamic UI text**: window references (12-month/24-month) update based on the actual window used
- **Improved discrepancy messages**: small diffs (1-2 pts) explained as rounding; larger gaps prompt user to report
- **Filed #52** for hole count weighting as a future enhancement

Fixes #50

## Test plan
- [x] All 41 tests pass (7 accuracy regression + 17 unit + 17 home)
- [x] 8 new unit tests covering all three rule changes
- [x] Existing accuracy regression tests unchanged — no impact on real player ratings
- [x] Lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)