### PR TITLE
feat: support rating calculation for expired/unrenewed members

### DIFF
--- a/pdga_whats_my_rating/Home.py
+++ b/pdga_whats_my_rating/Home.py
@@ -97,11 +97,16 @@ def show_player(pdga_no):
     if player.ratings_detail_df is None:
         st.markdown(f"### [{player.name}](https://pdga.com/player/{pdga_no})")
         st.write(
-            "no data available. could be an expired member"
-            " or they haven't played tournaments"
-            " in a while."
+            "no data available. this player may not have played any rated tournaments."
         )
         return
+
+    if player.membership_status and "Current" not in player.membership_status:
+        st.warning(
+            f"⚠️ Membership status: **{player.membership_status}**. "
+            "This player has no official rating, but we can still calculate "
+            "an unofficial rating from their round history."
+        )
 
     df = player.ratings_detail_df
 
@@ -124,52 +129,58 @@ def show_player(pdga_no):
         " \n💡*bookmark this page to save this search!*"
     )
     col1, col2 = st.columns(2)
+    delta = (calc_rating - official_rating) if official_rating is not None else None
     col1.metric(
         "Calculated Unofficial Rating (as of RIGHT NOW)",
         calc_rating,
-        (calc_rating - official_rating),
+        delta,
     )
     eval_mask = df["evaluated"] == "Yes"
     n_evaluated = len(df[eval_mask])
     n_used = len(df[df["used"] == "Yes"])
 
-    if player.new_tournaments is None and calc_rating != official_rating:
-        diff = abs(calc_rating - official_rating)
-        link = _mailto(
-            f"What's My Rating - Rating Discrepancy (PDGA #{pdga_no})",
-            f"PDGA Number: {pdga_no}\n"
-            f"Calculated Rating: {calc_rating}\n"
-            f"Official Rating: {official_rating}\n"
-            f"Difference: {diff}\n"
-            f"Rounds Evaluated: {n_evaluated}\n"
-            f"Rounds Used: {n_used}\n",
+    if official_rating is not None:
+        if player.new_tournaments is None and calc_rating != official_rating:
+            diff = abs(calc_rating - official_rating)
+            link = _mailto(
+                f"What's My Rating - Rating Discrepancy (PDGA #{pdga_no})",
+                f"PDGA Number: {pdga_no}\n"
+                f"Calculated Rating: {calc_rating}\n"
+                f"Official Rating: {official_rating}\n"
+                f"Difference: {diff}\n"
+                f"Rounds Evaluated: {n_evaluated}\n"
+                f"Rounds Used: {n_used}\n",
+            )
+            if diff <= 2:
+                msg = (
+                    f"*You have no new rounds, so our calculation"
+                    f" should match your official rating exactly,"
+                    f" but we're off by {diff}. Small differences"
+                    f" are usually due to rounding or minor aspects"
+                    f" of the PDGA algorithm we can't fully replicate"
+                    f" (e.g. hole count weighting).*"
+                )
+            else:
+                msg = (
+                    f"*You have no new rounds, so our calculation"
+                    f" should match your official rating exactly,"
+                    f" but we're off by {diff}. Small differences"
+                    f" can happen due to rounding, but this gap is"
+                    f" larger than expected."
+                )
+                if link:
+                    msg += (
+                        f" Please [let me know]({link}) so I can improve the algorithm!"
+                    )
+                msg += "*"
+            col1.markdown(msg)
+        col2.metric(
+            f"Official Rating {player.rating_date}",
+            official_rating,
+            player.rating_change,
         )
-        if diff <= 2:
-            msg = (
-                f"*You have no new rounds, so our calculation"
-                f" should match your official rating exactly,"
-                f" but we're off by {diff}. Small differences"
-                f" are usually due to rounding or minor aspects"
-                f" of the PDGA algorithm we can't fully replicate"
-                f" (e.g. hole count weighting).*"
-            )
-        else:
-            msg = (
-                f"*You have no new rounds, so our calculation"
-                f" should match your official rating exactly,"
-                f" but we're off by {diff}. Small differences"
-                f" can happen due to rounding, but this gap is"
-                f" larger than expected."
-            )
-            if link:
-                msg += f" Please [let me know]({link}) so I can improve the algorithm!"
-            msg += "*"
-        col1.markdown(msg)
-    col2.metric(
-        f"Official Rating {player.rating_date}",
-        official_rating,
-        player.rating_change,
-    )
+    else:
+        col2.metric("Official Rating", "N/A")
 
     avg_rating = df.loc[eval_mask, "rating"].mean()
     std_dev = df.loc[eval_mask, "rating"].std(ddof=0)

--- a/pdga_whats_my_rating/classes/player.py
+++ b/pdga_whats_my_rating/classes/player.py
@@ -19,6 +19,7 @@ class Player:
         self.cur_rating = None
         self.rating_change = None
         self.rating_date = None
+        self.membership_status = None
         self.ratings_detail_df = None
         self.new_tournaments = None
 
@@ -26,7 +27,7 @@ class Player:
 
         self._fetch_basic_info()
         self._fetch_ratings_detail()
-        if self.ratings_detail_df is not None:
+        if self.ratings_detail_df is not None and self.rating_date is not None:
             self._fetch_recent_events()
             if self.new_tournaments is not None:
                 self._add_new_tournaments()
@@ -53,6 +54,16 @@ class Player:
 
         rating_date = soup.find("small", {"class": "rating-date"})
         self.rating_date = rating_date.text if rating_date else None
+
+        membership_label = soup.find("strong", string=re.compile(r"Membership Status"))
+        if membership_label:
+            parts = []
+            for sibling in membership_label.next_siblings:
+                if hasattr(sibling, "get_text"):
+                    parts.append(sibling.get_text())
+                else:
+                    parts.append(str(sibling))
+            self.membership_status = " ".join("".join(parts).split())
 
     def _fetch_ratings_detail(self):
         URL = f"https://www.pdga.com/player/{self.pdga_no}/details"

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -21,6 +21,7 @@ def _make_mock_player(
     rating_date="(as of 11-Nov-2025)",
     fixture_file="player_27523_2025-11-11.csv",
     new_tournaments=None,
+    membership_status="Current (through 31-Dec-2026)",
 ):
     """Build a mock Player with real fixture data."""
     player = MagicMock()
@@ -30,6 +31,7 @@ def _make_mock_player(
     player.rating_change = rating_change
     player.rating_date = rating_date
     player.new_tournaments = new_tournaments
+    player.membership_status = membership_status
 
     if fixture_file:
         df = pd.read_csv(f"{FIXTURES_DIR}/{fixture_file}", parse_dates=["date"])
@@ -301,6 +303,53 @@ class TestOutlierRounds:
         assert not at.exception
         markdown_texts = [m.value for m in at.markdown]
         assert any("No rounds dropped as outliers" in m for m in markdown_texts)
+
+
+class TestExpiredMember:
+    def _run_expired(self):
+        """Run with an expired member who has round data but no official rating."""
+        mock_player = _make_mock_player(
+            pdga_no="123400",
+            name="Expired Player",
+            cur_rating=None,
+            rating_change=None,
+            rating_date=None,
+            membership_status="Expired (as of 31-Dec-2025)",
+        )
+        with (
+            patch(
+                "classes.player.Player.__init__",
+                lambda self, *a, **kw: None,
+            ),
+            patch(
+                "classes.player.Player.__new__",
+                lambda cls, *a, **kw: mock_player,
+            ),
+        ):
+            return _run_with_input("123400")
+
+    def test_renders_without_error(self):
+        at = self._run_expired()
+        assert not at.exception
+
+    def test_shows_membership_warning(self):
+        at = self._run_expired()
+        assert not at.exception
+        assert len(at.warning) >= 1
+        assert any("Expired" in w.value for w in at.warning)
+
+    def test_shows_calculated_rating(self):
+        at = self._run_expired()
+        assert not at.exception
+        assert len(at.metric) >= 1
+        calc_metric = at.metric[0]
+        assert calc_metric.label == "Calculated Unofficial Rating (as of RIGHT NOW)"
+
+    def test_shows_no_official_rating(self):
+        at = self._run_expired()
+        assert not at.exception
+        official_metric = at.metric[1]
+        assert official_metric.value == "N/A"
 
 
 class TestQueryParams:


### PR DESCRIPTION
## Summary
- Scrape membership status from player profile page using `<strong>Membership Status:</strong>` label and its sibling elements
- Show warning banner for non-current members (expired, etc.)
- Guard against `None` official rating — display "N/A" metric, skip discrepancy checks, and compute delta only when available
- Skip `_fetch_recent_events()` when `rating_date` is None (expired members have no baseline date)
- Add `TestExpiredMember` test class with 4 tests covering the expired member flow

Fixes #35

## Test plan
- [x] `uv run ruff check . && uv run ruff format --check .` passes
- [x] `uv run pytest` — all 45 tests pass
- [x] Manual: enter PDGA #123400 (expired member) — shows warning + calculated rating, no crash
- [x] Manual: enter PDGA #12989 (current/HoF member) — no warning shown, normal flow
- [x] Manual: enter PDGA #27523 (current member) — no warning shown, normal flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)