### PR TITLE
feat: retry with exponential backoff for PDGA 429 rate limits

### DIFF
--- a/pdga_whats_my_rating/Home.py
+++ b/pdga_whats_my_rating/Home.py
@@ -53,7 +53,13 @@ def show_player(pdga_no):
 
     st.query_params["pdga_no"] = pdga_no
     try:
-        player = Player(pdga_no)
+        player = Player(
+            pdga_no,
+            on_retry=lambda attempt, wait: st.warning(
+                f"PDGA.com rate limit hit. Retrying in {wait:.0f}s..."
+                f" (attempt {attempt + 1})"
+            ),
+        )
     except requests.exceptions.HTTPError as e:
         if e.response is not None and e.response.status_code == 429:
             st.error(

--- a/pdga_whats_my_rating/classes/player.py
+++ b/pdga_whats_my_rating/classes/player.py
@@ -1,5 +1,7 @@
 import logging
 import re
+import time
+from collections.abc import Callable
 from io import StringIO
 
 import pandas as pd
@@ -9,11 +11,38 @@ from bs4 import BeautifulSoup
 logger = logging.getLogger(__name__)
 
 REQUEST_TIMEOUT = 10
+MAX_RETRIES = 4
+INITIAL_BACKOFF = 2  # seconds
+MAX_BACKOFF = 30  # seconds
+
+
+def _request_with_retry(
+    url: str,
+    *,
+    timeout: int = REQUEST_TIMEOUT,
+    on_retry: Callable[[int, float], None] | None = None,
+) -> requests.Response:
+    """Make a GET request with exponential backoff on 429 responses."""
+    last_response = None
+    for attempt in range(MAX_RETRIES + 1):
+        response = requests.get(url, timeout=timeout)
+        if response.status_code != 429:
+            response.raise_for_status()
+            return response
+        last_response = response
+        if attempt < MAX_RETRIES:
+            wait_time = min(INITIAL_BACKOFF * 2**attempt, MAX_BACKOFF)
+            if on_retry is not None:
+                on_retry(attempt, wait_time)
+            time.sleep(wait_time)
+    last_response.raise_for_status()
+    return last_response  # unreachable, but satisfies type checker
 
 
 class Player:
-    def __init__(self, pdga_no: int):
+    def __init__(self, pdga_no: int, *, on_retry=None):
         self.pdga_no = pdga_no
+        self._on_retry = on_retry
         self.name = None
         self.location = None
         self.cur_rating = None
@@ -34,8 +63,7 @@ class Player:
 
     def _fetch_basic_info(self):
         URL = f"https://www.pdga.com/player/{self.pdga_no}"
-        response = requests.get(URL, timeout=REQUEST_TIMEOUT)
-        response.raise_for_status()
+        response = _request_with_retry(URL, on_retry=self._on_retry)
         soup = BeautifulSoup(response.text, "html.parser")
         self.home_soup = soup
 
@@ -67,8 +95,7 @@ class Player:
 
     def _fetch_ratings_detail(self):
         URL = f"https://www.pdga.com/player/{self.pdga_no}/details"
-        response = requests.get(URL, timeout=REQUEST_TIMEOUT)
-        response.raise_for_status()
+        response = _request_with_retry(URL, on_retry=self._on_retry)
         try:
             df = pd.read_html(StringIO(response.text))[0]
         except ValueError:
@@ -142,10 +169,9 @@ class Player:
             tourn_name = tourns.loc[t, "Tournament"]
             try:
                 href = soup.find("a", string=tourn_name)["href"]
-                tour_page = requests.get(
-                    f"https://www.pdga.com{href}", timeout=REQUEST_TIMEOUT
+                tour_page = _request_with_retry(
+                    f"https://www.pdga.com{href}", on_retry=self._on_retry
                 )
-                tour_page.raise_for_status()
                 tour_soup = BeautifulSoup(tour_page.text, "html.parser")
 
                 for table in tour_soup.find_all("table")[1:]:

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,80 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from classes.player import (
+    INITIAL_BACKOFF,
+    MAX_BACKOFF,
+    MAX_RETRIES,
+    _request_with_retry,
+)
+
+
+def _make_response(status_code):
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(response=resp)
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+@patch("classes.player.time.sleep")
+@patch("classes.player.requests.get")
+class TestRequestWithRetry:
+    def test_success_first_try(self, mock_get, mock_sleep):
+        mock_get.return_value = _make_response(200)
+        resp = _request_with_retry("https://example.com")
+        assert resp.status_code == 200
+        mock_sleep.assert_not_called()
+
+    def test_429_then_success(self, mock_get, mock_sleep):
+        mock_get.side_effect = [_make_response(429), _make_response(200)]
+        resp = _request_with_retry("https://example.com")
+        assert resp.status_code == 200
+        mock_sleep.assert_called_once_with(INITIAL_BACKOFF)
+
+    def test_multiple_429s_then_success(self, mock_get, mock_sleep):
+        mock_get.side_effect = [
+            _make_response(429),
+            _make_response(429),
+            _make_response(429),
+            _make_response(200),
+        ]
+        resp = _request_with_retry("https://example.com")
+        assert resp.status_code == 200
+        expected_waits = [INITIAL_BACKOFF * 2**i for i in range(3)]
+        actual_waits = [call.args[0] for call in mock_sleep.call_args_list]
+        assert actual_waits == expected_waits
+
+    def test_all_retries_exhausted(self, mock_get, mock_sleep):
+        mock_get.return_value = _make_response(429)
+        with pytest.raises(requests.exceptions.HTTPError):
+            _request_with_retry("https://example.com")
+        assert mock_sleep.call_count == MAX_RETRIES
+
+    def test_backoff_capped_at_max(self, mock_get, mock_sleep):
+        mock_get.return_value = _make_response(429)
+        with pytest.raises(requests.exceptions.HTTPError):
+            _request_with_retry("https://example.com")
+        actual_waits = [call.args[0] for call in mock_sleep.call_args_list]
+        for wait in actual_waits:
+            assert wait <= MAX_BACKOFF
+
+    def test_non_429_error_raises_immediately(self, mock_get, mock_sleep):
+        mock_get.return_value = _make_response(500)
+        with pytest.raises(requests.exceptions.HTTPError):
+            _request_with_retry("https://example.com")
+        mock_sleep.assert_not_called()
+
+    def test_on_retry_callback_invoked(self, mock_get, mock_sleep):
+        mock_get.side_effect = [_make_response(429), _make_response(200)]
+        callback = MagicMock()
+        _request_with_retry("https://example.com", on_retry=callback)
+        callback.assert_called_once_with(0, INITIAL_BACKOFF)
+
+    def test_on_retry_none_works(self, mock_get, mock_sleep):
+        mock_get.side_effect = [_make_response(429), _make_response(200)]
+        resp = _request_with_retry("https://example.com", on_retry=None)
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Add `_request_with_retry()` helper in `player.py` that retries on HTTP 429 with exponential backoff (2s, 4s, 8s, 16s, capped at 30s, up to 4 retries)
- Replace all 3 `requests.get()` call sites in `Player` with the retry helper
- Surface retry warnings to users via `on_retry` callback (shows `st.warning` in the UI)
- Existing 429 error handler in `Home.py` remains as the final fallback after all retries are exhausted

Fixes #57

## Test plan
- [x] 8 new unit tests in `test_retry.py` covering success, single/multiple retries, exhausted retries, backoff cap, non-429 errors, callback invocation, and `None` callback
- [x] All 53 tests pass
- [x] Manual test: run the app and look up a player to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)