### PR TITLE
fix: exclude unrated tournaments from rating calculation

### DIFF
--- a/pdga_whats_my_rating/utils/rating_calc.py
+++ b/pdga_whats_my_rating/utils/rating_calc.py
@@ -23,6 +23,7 @@ def calculate_rating(df):
     df["used"] = "No"
 
     df = df[df.tier != "XM"]
+    df = df[~df.tournament.str.contains("(Unrated)", case=False, na=False, regex=False)]
 
     # set valid dates to 1
     max_date = df["date"].max()

--- a/pdga_whats_my_rating/utils/rating_calc.py
+++ b/pdga_whats_my_rating/utils/rating_calc.py
@@ -23,18 +23,18 @@ def calculate_rating(df):
     df["used"] = "No"
 
     df = df[df.tier != "XM"]
-    df = df[~df.tournament.str.contains("(Unrated)", case=False, na=False, regex=False)]
+    unrated = df.tournament.str.contains("(Unrated)", case=False, na=False, regex=False)
 
     # set valid dates to 1
-    max_date = df["date"].max()
+    max_date = df.loc[~unrated, "date"].max()
     min_date = max_date - pd.DateOffset(years=1)
-    valid_dates = df["date"] >= min_date
+    valid_dates = (df["date"] >= min_date) & ~unrated
 
     # If <8 rounds in 12 months, extend to 24 months (PDGA rule)
     window_months = 12
     if valid_dates.sum() < 8:
         min_date = max_date - pd.DateOffset(years=2)
-        valid_dates = df["date"] >= min_date
+        valid_dates = (df["date"] >= min_date) & ~unrated
         window_months = 24
 
     df.loc[valid_dates, "weight"] = 1

--- a/tests/fixtures/player_298827_2026-03-10.csv
+++ b/tests/fixtures/player_298827_2026-03-10.csv
@@ -1,0 +1,5 @@
+tournament,date,tier,division,round,rating,evaluated,used
+Presidents Day Singles at Mellomar,2026-02-16,C,RAG,1,783,Yes,Yes
+SOMD ICE BOWL (Unrated),2026-01-18,XC,MA1,1,818,No,No
+The Southern Maryland Classic,2025-04-06,C/B,MA4,1,773,Yes,Yes
+The Southern Maryland Classic,2025-04-06,C/B,MA4,2,747,Yes,Yes

--- a/tests/test_rating_accuracy.py
+++ b/tests/test_rating_accuracy.py
@@ -32,6 +32,8 @@ FIXTURES_DIR = "tests/fixtures"
         ("player_12989_2026-02-10.csv", 1002, 2),
         # Ben Adinolfi - official 940 as of 2025-11-11
         ("player_146195_2025-11-11.csv", 940, 2),
+        # Tyler Adkins - official 768 as of 2026-03-10 (has unrated tournament)
+        ("player_298827_2026-03-10.csv", 768, 2),
     ],
 )
 def test_matches_official_rating(fixture_file, official_rating, tolerance):

--- a/tests/test_rating_calc.py
+++ b/tests/test_rating_calc.py
@@ -6,7 +6,7 @@ import pandas as pd
 from utils.rating_calc import calculate_rating
 
 
-def make_df(ratings, dates=None, tiers=None, rounds=None):
+def make_df(ratings, dates=None, tiers=None, rounds=None, tournaments=None):
     """Helper to build a ratings DataFrame for testing."""
     n = len(ratings)
     if dates is None:
@@ -16,12 +16,15 @@ def make_df(ratings, dates=None, tiers=None, rounds=None):
         tiers = ["A"] * n
     if rounds is None:
         rounds = [1] * n
+    if tournaments is None:
+        tournaments = ["Test Tournament"] * n
     return pd.DataFrame(
         {
             "rating": ratings,
             "date": pd.to_datetime(dates),
             "tier": tiers,
             "round": rounds,
+            "tournament": tournaments,
         }
     )
 
@@ -52,6 +55,22 @@ class TestCalculateRating:
         result_df, calc_rating, _, _ = calculate_rating(df)
         assert "XM" not in result_df["tier"].values
         # Without the 800 XM round, rating should be higher
+        assert calc_rating > 800
+
+    def test_unrated_tournament_excluded(self):
+        """Tournaments with '(Unrated)' in the name should be excluded."""
+        ratings = [900, 910, 920, 905, 800]
+        tournaments = [
+            "Tournament A",
+            "Tournament B",
+            "Tournament C",
+            "Tournament D",
+            "SOMD ICE BOWL (Unrated)",
+        ]
+        df = make_df(ratings, tournaments=tournaments)
+        result_df, calc_rating, _, _ = calculate_rating(df)
+        assert "(Unrated)" not in " ".join(result_df["tournament"].values)
+        # Without the 800 unrated round, rating should be higher
         assert calc_rating > 800
 
     def test_12_month_window(self):

--- a/tests/test_rating_calc.py
+++ b/tests/test_rating_calc.py
@@ -58,7 +58,7 @@ class TestCalculateRating:
         assert calc_rating > 800
 
     def test_unrated_tournament_excluded(self):
-        """Tournaments with '(Unrated)' in the name should be excluded."""
+        """Tournaments with '(Unrated)' in the name should not be evaluated."""
         ratings = [900, 910, 920, 905, 800]
         tournaments = [
             "Tournament A",
@@ -69,7 +69,11 @@ class TestCalculateRating:
         ]
         df = make_df(ratings, tournaments=tournaments)
         result_df, calc_rating, _, _ = calculate_rating(df)
-        assert "(Unrated)" not in " ".join(result_df["tournament"].values)
+        unrated_row = result_df[
+            result_df["tournament"] == "SOMD ICE BOWL (Unrated)"
+        ].iloc[0]
+        assert unrated_row["evaluated"] == "No"
+        assert unrated_row["weight"] == 0
         # Without the 800 unrated round, rating should be higher
         assert calc_rating > 800
 


### PR DESCRIPTION
## Summary
- Filter out tournaments with "(Unrated)" in the name from rating calculation
- Previously only XM tier was excluded; unrated tournaments (any tier) were incorrectly included
- Adds unit test for unrated tournament exclusion
- Adds player 298827 as accuracy regression test (exact match at 768)

Fixes #60

## Test plan
- [x] New unit test `test_unrated_tournament_excluded` passes
- [x] New accuracy test for player 298827 passes (exact match)
- [x] All 55 existing tests pass
- [x] Lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)